### PR TITLE
fix an exception when a valid node is missing

### DIFF
--- a/b2c/__init__.py
+++ b/b2c/__init__.py
@@ -26,7 +26,8 @@ def convert(json_file):
                 item["uri"] = uri
                 for field in undefined_fields:
                     item[field] = ""
-            if index != len(nodes) - 1:
+            if index != len(nodes) - 1 and nodes[index + 1] in item:
                 item[nodes[index + 1]] = format_level(item[nodes[index + 1]], index + 1)
         return tree
+
     return format_level(json_file)


### PR DESCRIPTION
When a feature doesn't have any scenario the behave json has the elements field missing.

This fix will skip the missing node on while parsing.