### PR TITLE
Convert table items so the tables will be displayed correctly in cucu…

### DIFF
--- a/b2c/__init__.py
+++ b/b2c/__init__.py
@@ -18,6 +18,14 @@ def convert(json_file):
                         item["result"]["error_message"] = (str(error_msg).replace("\"", ""))[:2000]
                 else:
                     item["result"] = {"status": "skipped", "duration": 0}
+                
+                if 'table' in item:
+                    item['rows'] = []
+                    t_line = 1
+                    item['rows'].append({"cells": item['table']['headings'], "line": item["line"] + t_line})
+                    for table_row in item['table']['rows']:
+                        t_line += 1
+                        item['rows'].append({"cells": table_row, "line": item["line"] + t_line})
             else:
                 item["uri"] = uri
                 item["description"] = ""


### PR DESCRIPTION
When I set up my automations on jenkins, I found that the tables are not displayed correctly in my cucumber report. After taking a look at the code I found that it doesn't convert the "table" items of behave json to "rows" item of cucumber json. 
I am not familiar with the coding format of python so maybe there is a better way to convert the tables. Hope you can give me some advice on how to convert this part properly.
I am using this in my automation and it seems to be working well with the cucumber report generator plugin of jenkins.